### PR TITLE
Lighten datepicker background a bit

### DIFF
--- a/src/scss/_layout.scss
+++ b/src/scss/_layout.scss
@@ -71,7 +71,7 @@ sd-app {
   float: left;
 
   .well {
-    background-color: $brand-info;
+    background-color: transparentize($brand-info, 0.5);
     border: 0;
   }
 }


### PR DESCRIPTION
Datepicker background contrast feels too "hard" to the rest of the app. Made it 50% transparent.