### PR TITLE
Fix unnecessary rerenders in datepicker

### DIFF
--- a/src/app/archive/datepicker/datepicker.component.ts
+++ b/src/app/archive/datepicker/datepicker.component.ts
@@ -1,13 +1,28 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Router, NavigationEnd } from '@angular/router';
 import { ISubscription } from 'rxjs/Subscription';
+import * as moment from 'moment';
+
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/interval';
+import 'rxjs/add/operator/startWith';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/distinctUntilChanged';
+
+const TODAY_UPDATE_INTERVAL = 5000;
 
 @Component({
   moduleId: module.id,
   selector: 'sd-datepicker',
-  templateUrl: 'datepicker.html',
+  templateUrl: 'datepicker.html'
 })
 export class DatepickerComponent implements OnInit, OnDestroy  {
+
+  public today$ = Observable.interval(TODAY_UPDATE_INTERVAL)
+    .startWith(0)
+    .map(() => moment().format('YYYY-MM-DD'))
+    .distinctUntilChanged()
+    .map(dateStr => new Date(dateStr));
 
   private _date: Date | void;
   private sub: ISubscription;
@@ -52,7 +67,7 @@ export class DatepickerComponent implements OnInit, OnDestroy  {
   private setDateFromRoute() {
     const state = <any>this.router.routerState;
     const dateRoute = state.firstChild(state.firstChild(state.root));
-    if (dateRoute && dateRoute.url.value[0] && dateRoute.url.value[0].path.match(/\d{4}/)) {
+    if (dateRoute && dateRoute.url.value[0] && /\d{4}/.test(dateRoute.url.value[0].path)) {
       this.setDateFromParams(dateRoute.snapshot.params);
     }
   }

--- a/src/app/archive/datepicker/datepicker.component.ts
+++ b/src/app/archive/datepicker/datepicker.component.ts
@@ -60,10 +60,6 @@ export class DatepickerComponent implements OnInit, OnDestroy  {
     return 'day';
   }
 
-  public today(): Date {
-    return new Date();
-  }
-
   private setDateFromRoute() {
     const state = <any>this.router.routerState;
     const dateRoute = state.firstChild(state.firstChild(state.root));

--- a/src/app/archive/datepicker/datepicker.html
+++ b/src/app/archive/datepicker/datepicker.html
@@ -3,7 +3,7 @@
 <div style="display:inline-block;">
   <datepicker [(ngModel)]="date"
               [showWeeks]="false"
-              [maxDate]="today()"
+              [maxDate]="today$ | async"
               [startingDay]="1"
               [minMode]="getMode()">
   </datepicker>


### PR DESCRIPTION
As change detection runs quite often during playback, this caused high CPU usage on my notebook.