### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/radiorabe/raar-ui/security/code-scanning/4](https://github.com/radiorabe/raar-ui/security/code-scanning/4)

In general, the fix is to explicitly declare a `permissions` block that restricts the `GITHUB_TOKEN` to the least privilege needed. For this workflow, the job only needs to read repository contents (for `actions/checkout`) and does not appear to need any write permission, nor access to issues, pull requests, or other scopes.

The best fix is to add a `permissions` block at the workflow root (just under `name:` and before `on:`) so it applies to all jobs, including `test`. We can safely restrict permissions to `contents: read`, which is sufficient for checkout while preventing write access to the repo. No other scopes are required by the shown steps. Concretely, in `.github/workflows/build.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: Build`) and line 3 (`on:`). This documents the required permissions, ensures least privilege, and keeps existing functionality unchanged.

No additional imports, methods, or definitions are needed; this is a pure YAML configuration change in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
